### PR TITLE
Correct the `CIContext` color space

### DIFF
--- a/Histogram/Histogram/ViewController.swift
+++ b/Histogram/Histogram/ViewController.swift
@@ -60,7 +60,7 @@ class ViewController: UIViewController {
 	@IBOutlet weak var histogramView: UIImageView!
 	@IBOutlet weak var histogramView1: UIImageView!
 	
-	let context = CIContext()
+	let context = CIContext(options: [.workingColorSpace: NSNull()])
 
 	let names = ["Karla.jpg", "Kerze.jpg", "Gradient.png", "Radial.png", "Gaussian.png", "Linear1.png"]
 	var index = 0


### PR DESCRIPTION
@Thomas1956, you may have figured this out already, but the issue you're encountering is that `CIContext` assumes a GenericRGB colorspace. From the [`workingColorSpace` documentation](https://developer.apple.com/documentation/coreimage/cicontextoption/1437728-workingcolorspace):
>By default, Core Image assumes that processing nodes are 128 bits-per-pixel, linear light, premultiplied RGBA floating-point values that use the GenericRGB color space.
>
>To request that Core Image perform no color management, specify the NSNull object as the value for this key. Use this option for images that don’t contain color data (such as elevation maps, normal vector maps, and sampled function tables).

Setting the `CIContext.workingColorSpace` to `NSNull` is appropriate for generating the area histogram since its pixels don't contain color data, they are a sampled function table.

Here's the before and after:
| Before | After |
| ---- | --- |
| ![Before1](https://user-images.githubusercontent.com/915431/192296329-f7681553-39d5-4b05-9f2b-399690994423.png) | ![After1](https://user-images.githubusercontent.com/915431/192296381-d20a3d79-39d0-449f-b307-561cb74c17f5.png) |
| ![Before2](https://user-images.githubusercontent.com/915431/192296473-c5dafd40-106f-48a5-876c-7ee1b3d87c73.png) | ![After2](https://user-images.githubusercontent.com/915431/192296513-1df01995-5937-434a-84cf-e51744f68859.png) |

The `kCIInputScaleKey` parameter may need to be adjusted to adjust the height of the histogram display image